### PR TITLE
Safety heatmap: filter defunct zones

### DIFF
--- a/docs/safety_heatmap.html
+++ b/docs/safety_heatmap.html
@@ -541,6 +541,22 @@ Promise.all([
   }
 
   allAlarms = alarms;
+
+  // Filter out locations with zero alerts since 2026-02-28 (defunct/renamed zones)
+  const baselineCutoff = new Date('2026-02-28');
+  const activeLocations = new Set();
+  for (const row of allAlarms) {
+    const loc = (row.cities || '').trim();
+    if (loc && new Date(row.time) >= baselineCutoff) {
+      activeLocations.add(loc);
+    }
+  }
+  for (const name of Object.keys(locationPoints)) {
+    if (!activeLocations.has(name)) {
+      delete locationPoints[name];
+    }
+  }
+
   refresh();
   document.getElementById('loading').style.display = 'none';
 }).catch(err => {


### PR DESCRIPTION
## Summary
- Adds `docs/safety_heatmap.html` — a color-coded map showing alert frequency per location, highlighting the safest areas
- Filters out defunct/renamed zones that have had zero alerts since 2026-02-28, per feedback from @yuval-harpaz in #15

## Changes from previous PR (#15)
The original heatmap showed green dots for locations like מצוק עורבים that had zero alerts — but only because those zones were renamed/reorganized, not because they're actually safe. Now locations with no alerts since Feb 28 are excluded from the map entirely, while locations that pass this baseline check can still correctly show zero for the user's selected time range.

## Test plan
- [ ] Open `docs/safety_heatmap.html` via GitHub Pages
- [ ] Verify no phantom green dots for defunct zones
- [ ] Test slider (1-365 days) — legitimate locations can still show 0
- [ ] Test alert type filter checkboxes
- [ ] Test total/per-day toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)